### PR TITLE
full

### DIFF
--- a/views/full.liquid
+++ b/views/full.liquid
@@ -1,7 +1,7 @@
-<div class="layout layout--row layout--stretch">
+<div class="layout layout--row layout--stretch" style="height: 100%; width: 100%;">
   <!-- Left Column: Artwork -->
-  <div class="flex flex--col flex--center-x flex--center-y h-full">
-    <div class="flex flex--col flex--center-x h--max-[85cqh] lg:h--max-[60cqh] w--max-[50cqw]">
+  <div class="flex flex--col flex--center-x flex--center-y h-full" style="flex: 1; min-width: 0; min-height: 0;">
+    <div class="flex flex--col flex--center-x" style="flex: 1; min-height: 0; min-width: 0;">
       <div style="flex: 1 1 auto; display: flex; align-items: center; justify-content: center; min-height: 0; overflow: hidden;">
         <img
           src={{ pokemon_data.artwork }}
@@ -17,7 +17,7 @@
   </div>
 
   <!-- Right Column: Details -->
-  <div class="flex flex--col flex--left gap--xlarge h-full">
+  <div class="flex flex--col flex--left gap--xlarge h-full" style="flex: 1; min-width: 0; min-height: 0;">
     <div class="item">
       <div class="meta"></div>
       <div class="content">


### PR DESCRIPTION
**Issue**
The full screen preview in browser was not working for me, was only displaying the banner. The other views, half and quadrant worked fine. Some changes to the markup resolves it for me.

**Environment**
Server: byos_laravael 0.29.0 as well as larapaper 0.30.0
Browsers: Edge and Chrome
Device: PC browsers and rendered on Kindle PW3 running KOReader

**Suggested fix**
Claude suggested some changes:
- Root layout — added height: 100%; width: 100% so it actually fills the full-screen container, not just its natural content size.
- Left column image wrapper — changed from max-height: 80% (which doesn't resolve in a flex child without an explicit parent height) to flex: 1 with min-height: 0. This lets the flex container properly shrink and the image scale within it.
- Image itself — added max-height: 100%; max-width: 100%; object-fit: contain so it scales correctly without overflow.
- Both columns — added flex: 1; min-width: 0 to ensure equal column splitting and prevent content overflow in full-screen mode.

The min-height: 0 / min-width: 0 additions are the most critical fix — by default, flex children have min-height: auto which prevents them from shrinking below their content size, breaking percentage-based sizing on children like your image.
